### PR TITLE
Add note about requiring "stack" user

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ from tripleo-quickstart here.
 
 - CentOS 7
 - ideally on a bare metal host
-- user with passwordless sudo access
+- run as user 'stack' with passwordless sudo access
 
 # Instructions
 


### PR DESCRIPTION
configure_host puts a bunch of stuff in /home/stack
regardless of who ran the script for now lets just
use that user.