### PR TITLE
01_install_requirements: add stack user

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -53,3 +53,8 @@ if sudo [ ! -f /root/.ssh/id_rsa_virt_power ]; then
     sudo ssh-keygen -f /root/.ssh/id_rsa_virt_power -P ""
     sudo cat /root/.ssh/id_rsa_virt_power.pub | sudo tee -a /root/.ssh/authorized_keys
 fi
+
+# make sure stack user is created
+if sudo [ ! cat /etc/passwd | grep stack ]; then
+    useradd stack
+fi


### PR DESCRIPTION
`02_configure_host.sh` has a playbook which expects `stack` user to be present, so it should be created in `01_install_requirements`.

Not sure if this is an effective way to check that the user exists though