### PR TITLE
05_run_ocp: backup install config

### DIFF
--- a/05_run_ocp.sh
+++ b/05_run_ocp.sh
@@ -45,7 +45,7 @@ sshKey: |
 EOF
 fi
 
-
+cp ocp/install-config{,.backup}.yaml 
 $GOPATH/src/github.com/openshift/installer/bin/openshift-install --dir ocp --log-level=debug create ignition-configs
 
 # Here we can make any necessary changes to the ignition configs/manifests


### PR DESCRIPTION

`openshift-install create` would remove the config, so it should be
backed up as it might be useful