### PR TITLE
Check for user stack in /etc/passwd

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -55,6 +55,6 @@ if sudo [ ! -f /root/.ssh/id_rsa_virt_power ]; then
 fi
 
 # make sure stack user is created
-if sudo [ ! cat /etc/passwd | grep stack ]; then
+if ! sudo grep stack /etc/passwd; then
     useradd stack
 fi


### PR DESCRIPTION
Fix the bash syntax to test if the stack user needs to be created.
The old syntax failed with this error:

+ sudo '[' '!' cat /etc/passwd
+ grep stack ']'
grep: ]: No such file or directory
[: missing ']'