### PR TITLE
Add a newline after ssh key

### DIFF
--- a/05_run_ocp.sh
+++ b/05_run_ocp.sh
@@ -42,6 +42,7 @@ pullSecret: |
   ${PULL_SECRET}
 sshKey: |
   ${SSH_PUB_KEY}
+
 EOF
 fi
 


### PR DESCRIPTION
Otherwise, the ssh key isn't added properly to the bootstrap VM, and you can't log in.