### PR TITLE
be more robust when running vbmc start

### DIFF
--- a/tripleo-quickstart-config/roles/virtbmc/files/vbmc_start.sh
+++ b/tripleo-quickstart-config/roles/virtbmc/files/vbmc_start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+name="$1"
+
+status=$(vbmc show  -f value $name | grep status | cut -f2 -d' ')
+
+if [[ $status != "running" ]]; then
+    vbmc start $name
+fi

--- a/tripleo-quickstart-config/roles/virtbmc/tasks/configure-vbmc.yml
+++ b/tripleo-quickstart-config/roles/virtbmc/tasks/configure-vbmc.yml
@@ -83,8 +83,7 @@
   with_items: "{{ overcloud_nodes }}"
   become: true
 
-- name: Start the Virtual BMCs (virtualbmc >= 1.4.0+)
-  command: "vbmc start {{ item.name }}"
+- name: Start the Virtual BMCs
+  script: vbmc_start.sh {{ item.name }}
   with_items: "{{ overcloud_nodes }}"
   become: true
-


### PR DESCRIPTION
If the vbmc item being started is already running, the vbmc start command
reports an error. Use a wrapper script to check the status before trying
to start it.

Signed-off-by: Doug Hellmann <doug@doughellmann.com>