### PR TITLE
Fix key generation

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -45,7 +45,7 @@ sudo yum -y update
 sudo yum install -y bind-utils ansible python-netaddr python-virtualbmc libvirt libvirt-devel libvirt-daemon-kvm qemu-kvm virt-install jq
 
 if [ ! -f $HOME/.ssh/id_rsa.pub ]; then
-    ssh-keygen -A
+    ssh-keygen -f ~/.ssh/id_rsa -P ""
 fi
 
 # root needs a private key to talk to libvirt, see configure-vbmc.yml


### PR DESCRIPTION
-A here attempts to create host keys in /etc/ssh/ssh_host_*
this was probably done in error, and results in a bootstrap
image with no public keys, generate user keys instead.