### PR TITLE
Switch the BM nics to e1000

### DIFF
--- a/tripleo-quickstart-config/roles/common/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/common/defaults/main.yml
@@ -106,7 +106,7 @@ deploy_supplemental_node: false
 enable_tls_everywhere: false
 
 # allow the nic model to be overridden by environment variable
-overcloud_libvirt_nic_model: virtio
+overcloud_libvirt_nic_model: e1000
 
 # The overcloud will have three controllers, one compute node,
 # and a ceph storage node.


### PR DESCRIPTION
If using virtio UDP checksums arn't calculated and some
versions of dhclient drop them as a result. This includes
the version in the cirros image we are using so change to
e1000 to avoid problems.

Patch untested but I think this is where to set it....