### PR TITLE
Deploy the RHCOS image

### DIFF
--- a/05_run_ocp.sh
+++ b/05_run_ocp.sh
@@ -64,6 +64,7 @@ sudo cp ocp/bootstrap.ign ${IGN_FILE}
 ./get_rhcos_image.sh
 LATEST_IMAGE=$(ls -ltr redhat-coreos-maipo-*-qemu.qcow2 | tail -n1 | awk '{print $9}')
 sudo cp $LATEST_IMAGE /var/lib/libvirt/images/${CLUSTER_NAME}-bootstrap.qcow2
+sudo qemu-img resize /var/lib/libvirt/images/${CLUSTER_NAME}-bootstrap.qcow2 50G
 sudo virt-install --connect qemu:///system \
              --import \
              --name ${CLUSTER_NAME}-bootstrap \

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ openstack baremetal create ocp/master_nodes.json
 Then to deploy you can do e.g:
 
 ```
-openstack baremetal node set $NODE_UUID --instance-info image_source=https://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img --instance-info image_checksum=f8ab98ff5e73ebab884d80c9dc9c7290 --instance-info root_gb=10  --property root_device='{"name": "/dev/vda"}'
+# Set NODE_UUID to the uuid of the node you want to work with
+NODE_UUID=$(openstack baremetal node show openshift-master-0 -f value -c uuid)
+openstack baremetal node set $NODE_UUID --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack.qcow2 --instance-info image_checksum=2a38fafe0b9465937955e4d054b8db3a --instance-info root_gb=25 --property root_device='{"name": "/dev/vda"}'
 openstack baremetal node manage $NODE_UUID --wait
 openstack baremetal node provide $NODE_UUID --wait
 ```

--- a/ironic/Dockerfile
+++ b/ironic/Dockerfile
@@ -5,6 +5,7 @@ RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/triple
 RUN yum install -y openstack-ironic-api openstack-ironic-conductor rabbitmq-server crudini iproute dnsmasq httpd qemu-img iscsi-initiator-utils
 RUN mkdir -p /var/www/html/images
 RUN curl http://tarballs.openstack.org/ironic-python-agent/tinyipa/tinyipa-stable-rocky.tar.gz | tar -C /var/www/html/images/ -xzf -
+RUN curl --insecure --compressed -L -o /var/www/html/images/redhat-coreos-maipo-47.284-openstack.qcow2 https://releases-redhat-coreos-dev.cloud.paas.upshift.redhat.com/storage/releases/maipo/47.284/redhat-coreos-maipo-47.284-openstack.qcow2.gz
 
 RUN cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 RUN crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy noauth


### PR DESCRIPTION
Swap out our use of the cirros image for the RHCOS
image. Also needs more disk space on the bootstrap VM
the the image can be converted by ironic.