### PR TITLE
Setup a local DNS overlay so that BASE_DOMAIN queries would point to bootstrap

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -9,7 +9,7 @@ sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
 sudo yum -y update
 
 sudo yum -y install epel-release --enablerepo=extras
-sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang
+sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang dnsmasq NetworkManager
 
 sudo pip install lolcat
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ currently no cluster is actually created.
 When the VM is running, the script will show the IP and you can ssh to the
 VM via ssh core@IP.
 
-You can then add the IP to the /etc/hosts on the node with the hostname,
-e.g `sudo echo "192.168.122.235 ostest-api.test.metalkube.org" >> /etc/hosts`.
-
 Then you can interact with the k8s API on the bootstrap VM e.g
 `sudo oc status --verbose --config /etc/kubernetes/kubeconfig`.
 

--- a/libvirt_cleanup.sh
+++ b/libvirt_cleanup.sh
@@ -4,3 +4,4 @@ set -xe
 source common.sh
 
 ansible-playbook -b -vvv tripleo-quickstart-config/metalkube-teardown-playbook.yml -e @tripleo-quickstart-config/metalkube-nodes.yml -e local_working_dir=$HOME/.quickstart -e virthost=$HOSTNAME -e @config/environments/dev_privileged_libvirt.yml -i tripleo-quickstart-config/metalkube-inventory.ini
+sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf


### PR DESCRIPTION
Configure NetworkManager to set nameserver to a local dnsmasq, this removes the need for `/etc/hosts` changes. This nameserver would be configured as default in bootstrap and other VMs.

dnsmasq would have `${CLUSTER_NAME}-api.${BASE_DOMAIN}` entry pointing to bootkube. Later on, once masters are stood up, more entries should be added.