### PR TITLE
Image download updates

### DIFF
--- a/05_run_ocp.sh
+++ b/05_run_ocp.sh
@@ -105,8 +105,13 @@ ssh -o "StrictHostKeyChecking=no" core@$IP sudo mkdir /run/httpd
 
 # Build and start the ironic container
 cat ironic/Dockerfile | ssh -o "StrictHostKeyChecking=no" core@$IP sudo dd of=Dockerfile
-ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman build -t ironic:latest .
-ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman run -d --net host --privileged --name ironic -v /run:/run:shared -v /dev:/dev localhost/ironic
+ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman build \
+    --build-arg RHCOS_IMAGE_URL=${RHCOS_IMAGE_URL} \
+    --build-arg RHCOS_IMAGE_VERSION=${RHCOS_IMAGE_VERSION} \
+    --build-arg RHCOS_IMAGE_FILENAME_OPENSTACK=${RHCOS_IMAGE_FILENAME_OPENSTACK} \
+    -t ironic:latest .
+ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman run \
+    -d --net host --privileged --name ironic -v /run:/run:shared -v /dev:/dev localhost/ironic
 
 # Create a master_nodes.json file
 cat ~stack/ironic_nodes.json | jq '.nodes[0:3] |  {nodes: .}' | tee ocp/master_nodes.json

--- a/common.sh
+++ b/common.sh
@@ -23,6 +23,7 @@ if [ -z "$PULL_SECRET" ]; then
   exit 1
 fi
 
+export RHCOS_IMAGE_URL="https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/"
 export RHCOS_IMAGE_VERSION="${RHCOS_IMAGE_VERSION:-47.284}"
 export RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
 # FIXME(shardy) note the -openstack image doesn't work for libvirt
@@ -31,8 +32,8 @@ export RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
 # doesn't work - probably we need to download both as the
 # -openstack one may be needed for the baremetal nodes so we get
 # config drive support, or perhaps a completely new image?
-#export RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-openstack.qcow2"
 export RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-qemu.qcow2"
+export RHCOS_IMAGE_FILENAME_OPENSTACK="${RHCOS_IMAGE_NAME}-openstack.qcow2"
 
 # Log output automatically
 LOGDIR="$(dirname $0)/logs"

--- a/get_rhcos_image.sh
+++ b/get_rhcos_image.sh
@@ -4,5 +4,5 @@ set -xe
 source common.sh
 
 if [ ! -f "$RHCOS_IMAGE_FILENAME" ]; then
-    curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME}" "https://releases-redhat-coreos-dev.cloud.paas.upshift.redhat.com/storage/releases/maipo/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
+    curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
 fi

--- a/ironic/Dockerfile
+++ b/ironic/Dockerfile
@@ -5,7 +5,11 @@ RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/triple
 RUN yum install -y openstack-ironic-api openstack-ironic-conductor rabbitmq-server crudini iproute dnsmasq httpd qemu-img iscsi-initiator-utils
 RUN mkdir -p /var/www/html/images
 RUN curl http://tarballs.openstack.org/ironic-python-agent/tinyipa/tinyipa-stable-rocky.tar.gz | tar -C /var/www/html/images/ -xzf -
-RUN curl --insecure --compressed -L -o /var/www/html/images/redhat-coreos-maipo-47.284-openstack.qcow2 https://releases-redhat-coreos-dev.cloud.paas.upshift.redhat.com/storage/releases/maipo/47.284/redhat-coreos-maipo-47.284-openstack.qcow2.gz
+
+ARG RHCOS_IMAGE_FILENAME_OPENSTACK
+ARG RHCOS_IMAGE_URL
+ARG RHCOS_IMAGE_VERSION
+RUN curl --insecure --compressed -L -o /var/www/html/images/${RHCOS_IMAGE_FILENAME_OPENSTACK} ${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME_OPENSTACK}.gz
 
 RUN cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 RUN crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy noauth


### PR DESCRIPTION
Use an upstream location for the image download, and parameterize the docker build, which should make it easier to bump versions, and allows a fast local mirror for the 650MB qcow download :)