### PR TITLE
Set extradisks:false

### DIFF
--- a/tripleo-quickstart-config/metalkube-nodes.yml
+++ b/tripleo-quickstart-config/metalkube-nodes.yml
@@ -32,10 +32,10 @@ flavors:
     memory: '{{openshift_memory|default(default_memory)}}'
     disk: '{{openshift_disk|default(default_disk)}}'
     vcpu: '{{openshift_vcpu|default(default_vcpu)}}'
-    extradisks: true
+    extradisks: false
 
   openshift_worker:
     memory: '{{openshift_memory|default(default_memory)}}'
     disk: '{{openshift_disk|default(default_disk)}}'
     vcpu: '{{openshift_vcpu|default(default_vcpu)}}'
-    extradisks: true
+    extradisks: false


### PR DESCRIPTION
Currently we don't need these extra disks and they use up
space in the pool created in /home/stack - we can re-enable them
later (probably with smaller disk sizes) when we start testing with
storage.