### PR TITLE
Remove reference to image checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then to deploy you can do e.g:
 ```
 # Set NODE_UUID to the uuid of the node you want to work with
 NODE_UUID=$(openstack baremetal node show openshift-master-0 -f value -c uuid)
-openstack baremetal node set $NODE_UUID --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack.qcow2 --instance-info image_checksum=2a38fafe0b9465937955e4d054b8db3a --instance-info root_gb=25 --property root_device='{"name": "/dev/vda"}'
+openstack baremetal node set $NODE_UUID --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack.qcow2 --instance-info root_gb=25 --property root_device='{"name": "/dev/vda"}'
 openstack baremetal node manage $NODE_UUID --wait
 openstack baremetal node provide $NODE_UUID --wait
 ```


### PR DESCRIPTION
We're using iscsi deploy, which doesn't check a
checksum (direct deploy does), lets not mislead people.