### PR TITLE
Revert "Switch the BM nics to e1000"

### DIFF
--- a/tripleo-quickstart-config/roles/common/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/common/defaults/main.yml
@@ -106,7 +106,7 @@ deploy_supplemental_node: false
 enable_tls_everywhere: false
 
 # allow the nic model to be overridden by environment variable
-overcloud_libvirt_nic_model: e1000
+overcloud_libvirt_nic_model: virtio
 
 # The overcloud will have three controllers, one compute node,
 # and a ceph storage node.


### PR DESCRIPTION
Now that we are no longer using cirros we don't need this,
and as the deploy time is a lot faster with virtio (local tests
show dd of image accross iscsi goes from 150sec to 80) we
should switch back.

This reverts commit e63b3553797aab0d85a3f77beb46c1e979a84569.