### PR TITLE
If there is no stack user make the ser directory readable

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -57,4 +57,5 @@ fi
 # make sure stack user is created
 if ! cat /etc/passwd | grep -q "^stack:" ; then
     sudo useradd stack
+    sudo chmod 0755 ~stack
 fi


### PR DESCRIPTION
My usual workflow is reserving a machine in Beaker which gives root login there. When the script is running as root (instead of stack) it needs access to stack's home directory, otherwise the VM won't start.

This PR ensures stack homedir has necessary permissions if its has not created previously