### PR TITLE
Using local user instead of user stack

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -54,8 +54,3 @@ if sudo [ ! -f /root/.ssh/id_rsa_virt_power ]; then
     sudo cat /root/.ssh/id_rsa_virt_power.pub | sudo tee -a /root/.ssh/authorized_keys
 fi
 
-# make sure stack user is created
-if ! grep -q "^stack:" /etc/passwd; then
-    sudo useradd stack
-    sudo chmod 0755 ~stack
-fi

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -9,7 +9,10 @@ source common.sh
 # Note we copy the playbook so the roles/modules from tripleo-quickstart
 # are found without a special ansible.cfg
 export ANSIBLE_LIBRARY=./library
+
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
+    -e "non_root_user=$USER" \
+    -e "working_dir=$WORKING_DIR" \
     -e "roles_path=$PWD/roles" \
     -e @tripleo-quickstart-config/metalkube-nodes.yml \
     -e "local_working_dir=$HOME/.quickstart" \
@@ -18,7 +21,6 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -i tripleo-quickstart-config/metalkube-inventory.ini \
     -b -vvv tripleo-quickstart-config/metalkube-setup-playbook.yml \
     | tee "ansible-$(date -u +%Y%m%d%H%M).log"
-
 
 # Allow local non-root-user access to libvirt ref
 # https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#make-sure-you-have-permissions-for-qemusystem

--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -103,8 +103,8 @@ ssh -o "StrictHostKeyChecking=no" core@$IP sudo ifup eth1
 
 # Internal dnsmasq should reserve IP addresses for each master
 cp -f ironic/dnsmasq.conf /tmp
-for i in 0 1 2; do 
-  NODE_MAC=$(cat ~stack/ironic_nodes.json | jq -r ".nodes[${i}].ports[0].address")
+for i in 0 1 2; do
+  NODE_MAC=$(cat "${WORKING_DIR}/ironic_nodes.json" | jq -r ".nodes[${i}].ports[0].address")
   NODE_IP="172.22.0.2${i}"
   HOSTNAME="${CLUSTER_NAME}-etcd-${i}.${BASE_DOMAIN}"
   # Make sure internal dnsmasq would assign an expected IP
@@ -128,6 +128,6 @@ ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman run \
     -d --net host --privileged --name ironic localhost/ironic
 
 # Create a master_nodes.json file
-cat ~stack/ironic_nodes.json | jq '.nodes[0:3] |  {nodes: .}' | tee ocp/master_nodes.json
+jq '.nodes[0:3] | {nodes: .}' "${WORKING_DIR}/ironic_nodes.json" | tee ocp/master_nodes.json
 
 echo "You can now ssh to \"$IP\" as the core user"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ from tripleo-quickstart here.
 
 - CentOS 7
 - ideally on a bare metal host
-- run as user 'stack' with passwordless sudo access
-  - qemu needs access to this users home directory:
-    - `$ chmod 755 ~stack`
+- run as a user with passwordless sudo access
+- get a valid pull secret (json string) from https://cloud.openshift.com/clusters/install#pull-secret
 
 # Instructions
 

--- a/common.sh
+++ b/common.sh
@@ -2,6 +2,7 @@
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 USER=`whoami`
+WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
 
 if [ -z "$CONFIG" ]; then  
     # See if there's a config_$USER.sh in the SCRIPTDIR
@@ -21,6 +22,13 @@ if [ -z "$PULL_SECRET" ]; then
   echo "No valid PULL_SECRET set in ${CONFIG}"
   echo "Get a valid pull secret (json string) from https://cloud.openshift.com/clusters/install#pull-secret"
   exit 1
+fi
+
+if [ ! -d "$WORKING_DIR" ]; then
+    echo "Creating Working Dir"
+    sudo mkdir "$WORKING_DIR"
+    sudo chown "${USER}:${USER}" "$WORKING_DIR"
+    sudo chmod 755 "$WORKING_DIR"
 fi
 
 export RHCOS_IMAGE_URL=${RHCOS_IMAGE_URL:-"https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/"}

--- a/config/environments/dev_privileged_libvirt.yml
+++ b/config/environments/dev_privileged_libvirt.yml
@@ -2,9 +2,7 @@
 # you can use these options.  This also makes VMs survive reboots \o/
 # This is particularly useful for local development environments
 non_root_chown: true
-non_root_user: stack
-undercloud_user: stack
-working_dir: "/home/{{ non_root_user }}"
+undercloud_user: "{{ non_root_user }}"
 ssh_user: root
 libvirt_uri: qemu:///system
 

--- a/libvirt_cleanup.sh
+++ b/libvirt_cleanup.sh
@@ -3,5 +3,13 @@ set -xe
 
 source common.sh
 
-ansible-playbook -b -vvv tripleo-quickstart-config/metalkube-teardown-playbook.yml -e @tripleo-quickstart-config/metalkube-nodes.yml -e local_working_dir=$HOME/.quickstart -e virthost=$HOSTNAME -e @config/environments/dev_privileged_libvirt.yml -i tripleo-quickstart-config/metalkube-inventory.ini
+ANSIBLE_FORCE_COLOR=true ansible-playbook \
+    -e "working_dir=$WORKING_DIR" \
+    -e "local_working_dir=$HOME/.quickstart" \
+    -e "virthost=$HOSTNAME" \
+    -e @tripleo-quickstart-config/metalkube-nodes.yml \
+    -e @config/environments/dev_privileged_libvirt.yml \
+    -i tripleo-quickstart-config/metalkube-inventory.ini \
+    -b -vvv tripleo-quickstart-config/metalkube-teardown-playbook.yml
+
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf

--- a/tripleo-quickstart-config/roles/common/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/common/defaults/main.yml
@@ -4,16 +4,16 @@
 local_working_dir: "{{ lookup('env', 'HOME') }}/.quickstart"
 
 # this will define the user that ansible will connect with
-ssh_user: stack
+ssh_user: "{{ non_root_user }}"
 
 # This defines the users that deploys the overcloud from the undercloud
 # and accesses overcloud as the orchestration admin user
-undercloud_user: stack
+undercloud_user: "{{ non_root_user }}"
 overcloud_user: heat-admin
 
 # This is where we store generated artifacts (like ssh config files,
 # keys, deployment scripts, etc) on the undercloud.
-working_dir: "/home/{{ undercloud_user }}"
+#working_dir: "/opt/dev-scripts"
 
 # This is a directory no the virthost in which we store the downloaded
 # undercloud image.
@@ -186,7 +186,6 @@ tuned_profile: 'virtual-host'
 
 # This is the name of the user the `provision` role will create on the
 # remote host.
-non_root_user: stack
 non_root_group: "{{ non_root_user }}"
 
 # Path for volume storage


### PR DESCRIPTION
Using local user instead of user stack

This patch removes the need to create the user stack and just
uses a local user.
Instead of using the homedir, it creates a working-dir
/opt/dev-scripts to store temporary files.

Fixes #28