### PR TITLE
Set necessary DNS in dnsmasq config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ And to deploy a master node with the coreos image (image\_source above) and pass
 ```
 mkdir -p configdrive/openstack/latest
 cp ocp/master.ign configdrive/openstack/latest/user_data
-openstack baremetal node deploy --config-drive configdrive $NODE_UUID
+openstack baremetal node deploy --config-drive configdrive $NODE_UUID --wait
 ```
 
 To ssh to the master nodes, you can route trafic through the bootstrap node
 ```
-sudo ip route add 172.22.0.0/24 via $(getent hosts ostest-api.test.metalkube.org | awk '{ print $1 }')
-ssh core@<IP> # For the moment you have to get the IP form the dnsmasq logs in the ironic container
+sudo ip route add 172.22.0.0/24 via $(getent hosts ostest-api.test.metalkube.org | grep 192 | awk '{ print $1 }')
+ssh core@ostest-etcd-<n>.test.metalkube.org
 ```
 
 ## Cleanup
@@ -110,4 +110,3 @@ Or, you can run `make clean` which will run all of the cleanup steps.
 
 ## Troubleshooting
 If you're having trouble, try `systemctl restart libvirtd`.
-

--- a/ironic/Dockerfile
+++ b/ironic/Dockerfile
@@ -32,16 +32,8 @@ RUN mkdir /tftpboot
 
 RUN ironic-dbsync --config-file /etc/ironic/ironic.conf create_schema
 
-RUN echo "#!/usr/bin/bash" >> /bin/runironic
-RUN echo "/usr/lib/rabbitmq/bin/rabbitmq-server > /var/log/rabbit.out 2>&1 &" >> /bin/runironic
-RUN echo "/usr/bin/python2 /usr/bin/ironic-conductor > /var/log/ironic-conductor.out 2>&1 &" >> /bin/runironic
-RUN echo "/usr/bin/python2 /usr/bin/ironic-api > /var/log/ironic-api.out 2>&1 &" >> /bin/runironic
-RUN echo "/usr/sbin/httpd" >> /bin/runironic
-RUN echo "/usr/sbin/dnsmasq -d -q -i eth1 --dhcp-range 172.22.0.10,172.22.0.100 --enable-tftp --tftp-root=/tftpboot --dhcp-boot=http://172.22.0.1/boot.ipxe > /var/log/dnsmasq.out 2>&1 &" >> /bin/runironic
-RUN echo "sleep infinity" >> /bin/runironic
-
+COPY ./runironic.sh /bin/runironic
+COPY ./dnsmasq.conf /etc/dnsmasq.conf
 RUN chmod +x /bin/runironic
 
 ENTRYPOINT ["/bin/runironic"]
-
-

--- a/ironic/dnsmasq.conf
+++ b/ironic/dnsmasq.conf
@@ -1,0 +1,5 @@
+interface=eth1
+dhcp-range=172.22.0.10,172.22.0.100
+enable-tftp
+tftp-root=/tftpboot
+dhcp-boot=http://172.22.0.1/boot.ipxe

--- a/ironic/runironic.sh
+++ b/ironic/runironic.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+/usr/lib/rabbitmq/bin/rabbitmq-server > /var/log/rabbit.out 2>&1 &
+/usr/bin/python2 /usr/bin/ironic-conductor > /var/log/ironic-conductor.out 2>&1 &
+/usr/bin/python2 /usr/bin/ironic-api > /var/log/ironic-api.out 2>&1 &
+/usr/sbin/httpd
+/usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf > /var/log/dnsmasq.out 2>&1 &
+sleep infinity


### PR DESCRIPTION
This ensures that:
* bootstrap's dnsmasq allocates defined IPs for masters
* "external" DNS resolves these IPs to `<cluster-name>-etcd-<index>` name
* sets etcd discovery DNS entry