### PR TITLE
Switch to the "direct" deploy interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then to deploy you can do e.g:
 ```
 # Set NODE_UUID to the uuid of the node you want to work with
 NODE_UUID=$(openstack baremetal node show openshift-master-0 -f value -c uuid)
-openstack baremetal node set $NODE_UUID --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack.qcow2 --instance-info root_gb=25 --property root_device='{"name": "/dev/vda"}'
+openstack baremetal node set $NODE_UUID --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack.qcow2 --instance-info image_checksum=2a38fafe0b9465937955e4d054b8db3a --instance-info root_gb=25 --property root_device='{"name": "/dev/vda"}'
 openstack baremetal node manage $NODE_UUID --wait
 openstack baremetal node provide $NODE_UUID --wait
 ```

--- a/ironic/Dockerfile
+++ b/ironic/Dockerfile
@@ -18,6 +18,7 @@ RUN crudini --set /etc/ironic/ironic.conf DEFAULT debug true
 RUN crudini --set /etc/ironic/ironic.conf DEFAULT default_network_interface noop
 RUN crudini --set /etc/ironic/ironic.conf DEFAULT enabled_boot_interfaces pxe,ipxe
 RUN crudini --set /etc/ironic/ironic.conf DEFAULT default_boot_interface ipxe
+RUN crudini --set /etc/ironic/ironic.conf DEFAULT default_deploy_interface direct
 RUN crudini --set /etc/ironic/ironic.conf database connection sqlite:///ironic.db
 RUN crudini --set /etc/ironic/ironic.conf dhcp dhcp_provider none
 RUN crudini --set /etc/ironic/ironic.conf conductor automated_clean false


### PR DESCRIPTION
For a single node this preforms a little better(about 2min45 vs
3min15 in a local env), but it should scale a lot better as it
offloads most of the work from the controller to the nodes being
deployed.