### PR TITLE
stop syncing openstack specific integration

### DIFF
--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -38,9 +38,5 @@ function sync_go_repo_and_patch {
 
 sync_go_repo_and_patch github.com/openshift/installer https://github.com/openshift/installer.git
 
-sync_go_repo_and_patch github.com/terraform-providers/terraform-provider-openstack https://github.com/terraform-providers/terraform-provider-openstack
-
 # sync_go_repo_and_patch github.com/openshift/ci-operator https://github.com/openshift/ci-operator.git
 # sync_go_repo_and_patch github.com/sallyom/installer-e2e https://github.com/sallyom/installer-e2e.git
-
-sync_go_repo_and_patch sigs.k8s.io/openshift/cluster-api-provider-openstack https://github.com/openshift/cluster-api-provider-openstack.git


### PR DESCRIPTION
dev-scripts originates from github.com/imain/ocp-doit which targets
openshift 4.x installation on the openstack platform. This patch removes
some leftover repo sync that only slows down development.