### PR TITLE
cleanup: remove all ocp bits

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -4,8 +4,8 @@ set -e
 
 source ocp_install_env.sh
 
-$GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug --dir ocp destroy cluster
+$GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug --dir ocp destroy cluster || true
 
-rm -rf ocp/{auth,terraform.tfstate}
+rm -rf ocp
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf


### PR DESCRIPTION
* `cluster destroy` would fail as `images` pool is not used
* remove `ocp` directory so that a reinstall would work