### PR TITLE
Bare metal support

### DIFF
--- a/ironic/Dockerfile
+++ b/ironic/Dockerfile
@@ -4,7 +4,7 @@ RUN yum install -y python-requests
 RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo
 RUN yum install -y openstack-ironic-api openstack-ironic-conductor rabbitmq-server crudini iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk ipxe-bootimgs
 RUN mkdir -p /var/www/html/images
-RUN curl http://tarballs.openstack.org/ironic-python-agent/tinyipa/tinyipa-stable-rocky.tar.gz | tar -C /var/www/html/images/ -xzf -
+RUN curl https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar | tar -C /var/www/html/images/ -xf -
 
 ARG RHCOS_IMAGE_FILENAME_OPENSTACK
 ARG RHCOS_IMAGE_URL

--- a/ironic/Dockerfile
+++ b/ironic/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/centos:centos7
 
 RUN yum install -y python-requests
 RUN curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo
-RUN yum install -y openstack-ironic-api openstack-ironic-conductor rabbitmq-server crudini iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk
+RUN yum install -y openstack-ironic-api openstack-ironic-conductor rabbitmq-server crudini iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk ipxe-bootimgs
 RUN mkdir -p /var/www/html/images
 RUN curl http://tarballs.openstack.org/ironic-python-agent/tinyipa/tinyipa-stable-rocky.tar.gz | tar -C /var/www/html/images/ -xzf -
 
@@ -30,6 +30,7 @@ RUN crudini --set /etc/ironic/ironic.conf pxe ipxe_enabled true
 RUN crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
 
 RUN mkdir /tftpboot
+RUN cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/
 
 RUN ironic-dbsync --config-file /etc/ironic/ironic.conf create_schema
 

--- a/ironic/dnsmasq.conf
+++ b/ironic/dnsmasq.conf
@@ -2,4 +2,17 @@ interface=eth1
 dhcp-range=172.22.0.10,172.22.0.100
 enable-tftp
 tftp-root=/tftpboot
-dhcp-boot=http://172.22.0.1/boot.ipxe
+
+dhcp-match=ipxe,175
+# Client is already running iPXE; move to next stage of chainloading
+dhcp-boot=tag:ipxe,http://172.22.0.1/boot.ipxe
+
+# Note: Need to test EFI booting
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+dhcp-match=set:efi,option:client-arch,11
+# Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
+dhcp-boot=tag:efi,tag:!ipxe,ipxe.efi
+
+# Client is running PXE over BIOS; send BIOS version of iPXE chainloader
+dhcp-boot=/undionly.kpxe,172.22.0.1

--- a/tripleo-quickstart-config/metalkube-nodes.yml
+++ b/tripleo-quickstart-config/metalkube-nodes.yml
@@ -1,4 +1,4 @@
-openshift_memory: 4096
+openshift_memory: 6144
 default_vcpu: 2
 overcloud_nodes:
   - name: openshift_master_0

--- a/tripleo-quickstart-config/roles/libvirt/setup/overcloud/templates/ironic_nodes.json.j2
+++ b/tripleo-quickstart-config/roles/libvirt/setup/overcloud/templates/ironic_nodes.json.j2
@@ -19,8 +19,8 @@
         "ipmi_password": "password",
         "ipmi_address": "192.168.122.1",
         "ipmi_port": "{{ node.virtualbmc_port }}",
-        "deploy_kernel": "http://172.22.0.1/images/tinyipa-stable-rocky.vmlinuz",
-        "deploy_ramdisk": "http://172.22.0.1/images/tinyipa-stable-rocky.gz"
+        "deploy_kernel": "http://172.22.0.1/images/ironic-python-agent.kernel",
+        "deploy_ramdisk": "http://172.22.0.1/images/ironic-python-agent.initramfs"
       },
       "ports": [{
         "address": "{{ node_mac_map.get(node.name).get(lvars['pxe_network']) }}",


### PR DESCRIPTION
Allows us to boot the RHCOS image in a baremetal env (at least the one we've tested). The image boots but then fails to resolve ostest-api.test.metalkube.org. Which is better then we were.

Unfortunately the RDO IPA image has a bigger footprint, so needs a bump in RAM to fit the image download during deploy.

If merged this will require users to rerun the setup scripts from 02_...sh onwards