### PR TITLE
Ignition patching system

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -11,7 +11,7 @@ sudo yum -y update
 sudo yum -y install epel-release --enablerepo=extras
 sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang dnsmasq NetworkManager crudini
 
-sudo pip install lolcat
+sudo pip install lolcat json-patch
 
 # for tripleo-repos install
 sudo yum -y install python-setuptools python-requests

--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -5,6 +5,7 @@ set -e
 source ocp_install_env.sh
 source common.sh
 source get_rhcos_image.sh
+source utils.sh
 
 # FIXME this is configuring for the libvirt backend which is dev-only ref
 # https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md
@@ -62,6 +63,10 @@ $GOPATH/src/github.com/openshift/installer/bin/openshift-install --dir ocp --log
 # See https://coreos.com/os/docs/latest/booting-with-libvirt.html
 IGN_FILE="/var/lib/libvirt/images/${CLUSTER_NAME}-bootstrap.ign"
 sudo cp ocp/bootstrap.ign ${IGN_FILE}
+
+# Apply patches to bootstrap ignition
+apply_ignition_patches bootstrap "$IGN_FILE"
+
 LATEST_IMAGE=$(ls -ltr redhat-coreos-maipo-*-qemu.qcow2 | tail -n1 | awk '{print $9}')
 sudo cp $LATEST_IMAGE /var/lib/libvirt/images/${CLUSTER_NAME}-bootstrap.qcow2
 sudo qemu-img resize /var/lib/libvirt/images/${CLUSTER_NAME}-bootstrap.qcow2 50G

--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ Or, you can run `make clean` which will run all of the cleanup steps.
 
 ## Troubleshooting
 If you're having trouble, try `systemctl restart libvirtd`.
+
+You can use:
+
+```
+virsh console domain_name
+```
+
+To get to the bootstrap node. The username is `core` and the password is `notworking`

--- a/ignition_patches/bootstrap/01_core_user_pass.json
+++ b/ignition_patches/bootstrap/01_core_user_pass.json
@@ -1,0 +1,1 @@
+[{"op": "add", "path": "/passwd/users/0/passwordHash", "value": "$6$2Cy8WeZ7uGbJ4qEv$vS8zP0HvbhtOTfu72JMoYIxm3Zb5T2880.vjwr9jug57uvwjuWmSJzjw9mUjgdTL4QSG2dvDpGaKJLHY741d./"}]

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+function apply_ignition_patches() {
+local kind
+local target
+local target_name
+local wd
+local current
+local current_patch_name
+
+kind="$1"
+target="$2"
+wd=$(mktemp -d)
+target_name="$(basename "$target")"
+
+current="$target"
+for patch in "${PWD}/ignition_patches/${kind}/"*.json; do
+    current_patch_name="$(basename "$patch")"
+    jsonpatch "$current" "$patch" > "${wd}/${target_name}_${current_patch_name}"
+    current="${wd}/${target_name}_${current_patch_name}"
+done
+sudo cp "$current" "$target"
+}


### PR DESCRIPTION
This patch introduces a systematic way of patching ignition files and
provides a utility method for its usage.

All your patches to ignition files should follow jsonpatch rfc 6902.
You should place your patch json files in:

    json_patches/kind_of_machine

Then, in the code that starts the machine, you should run:

    apply_json_patches bootstrap "$IGN_FILE"

where bootstrap is the kind of machine from the possible:

- bootstrap
- masters
- workers

and IGN file is the ignition file that will be served to the machine via
PXE.

To run this, you should source utils.sh