### PR TITLE
ocp_cleanup.sh - don't use openshift install to clean up

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -4,8 +4,9 @@ set -e
 
 source ocp_install_env.sh
 
-$GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug --dir ocp destroy cluster || true
-
+sudo virsh destroy "${CLUSTER_NAME}-bootstrap"
+sudo virsh undefine "${CLUSTER_NAME}-bootstrap" --remove-all-storage
+VOL_POOL=$(sudo virsh vol-pool "/var/lib/libvirt/images/${CLUSTER_NAME}-bootstrap.ign")
+sudo virsh vol-delete "${CLUSTER_NAME}-bootstrap.ign" --pool "${VOL_POOL}"
 rm -rf ocp
-
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf


### PR DESCRIPTION
We don't use "create cluster", so it doesn't really make sense to use the inverse openshift-install operation - it kinda works by luck because we name the bootstrap VM with the expected prefix, but we should probably just manually clean the things created via 05_deploy_bootstrap_vm.sh instead.