### PR TITLE
bootstrap vm deployment: support multiple nets

### DIFF
--- a/pyxpath
+++ b/pyxpath
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import sys
+from lxml import etree
+
+try:
+    selector, xmlfile = sys.argv[1:]
+except Exception:
+    sys.stderr.write('Expects to be called with xpath selector AND a filename ('-' for stdin)\n')
+
+if xmlfile == '-':
+    source = sys.stdin
+else:
+    source = xmlfile
+
+doc = etree.parse(source)
+
+selection = doc.xpath(selector)
+for element in selection:
+    print(element)

--- a/utils.sh
+++ b/utils.sh
@@ -21,3 +21,33 @@ for patch in "${PWD}/ignition_patches/${kind}/"*.json; do
 done
 sudo cp "$current" "$target"
 }
+
+function net_iface_dhcp_ip() {
+local netname
+local hwaddr
+
+netname="$1"
+hwaddr="$2"
+sudo virsh net-dhcp-leases "$netname" | awk -v hwaddr="$hwaddr" '$3 ~ hwaddr {split($5, res, "/"); print res[1]}'
+}
+
+function domain_net_ip() {
+    local domain
+    local bridge_name
+    local net
+    local hwaddr
+    local rc
+
+    domain="$1"
+    net="$2"
+
+
+    bridge_name=$(sudo virsh net-dumpxml "$net" | "${PWD}/pyxpath" "//bridge/@name" -)
+    hwaddr=$(sudo virsh dumpxml "$domain" | "${PWD}/pyxpath" "//devices/interface[source/@bridge='$bridge_name']/mac/@address" -)
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        return $rc
+    fi
+
+    net_iface_dhcp_ip "$net" "$hwaddr"
+}


### PR DESCRIPTION
This patch gets us ready for when we add more nets to the deployment by
only retrieving the IP of one specific libvirt network. We had to drop
domifaddr because it misbehaved when there's multiple nets.