### PR TITLE
Check for MAC entrying in net-dhcp-leases before using it

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -28,6 +28,7 @@ local hwaddr
 
 netname="$1"
 hwaddr="$2"
+sudo virsh net-dhcp-leases "$netname" | grep -q "$hwaddr" || return 1
 sudo virsh net-dhcp-leases "$netname" | awk -v hwaddr="$hwaddr" '$3 ~ hwaddr {split($5, res, "/"); print res[1]}'
 }
 


### PR DESCRIPTION
There is a delay between the entry for a domain being created
in vibvirt and when the MAC entry appears in net-dhcp-leases (when
the host boots and does a dhcp request). We need to check the
entry has appeared before extracting it.