### PR TITLE
WIP Run bootstrap service in a container

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -9,7 +9,7 @@ sudo sed -i "s/=enforcing/=permissive/g" /etc/selinux/config
 sudo yum -y update
 
 sudo yum -y install epel-release --enablerepo=extras
-sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang dnsmasq NetworkManager crudini
+sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang dnsmasq NetworkManager crudini podman
 
 sudo pip install lolcat json-patch
 
@@ -53,4 +53,3 @@ if sudo [ ! -f /root/.ssh/id_rsa_virt_power ]; then
     sudo ssh-keygen -f /root/.ssh/id_rsa_virt_power -P ""
     sudo cat /root/.ssh/id_rsa_virt_power.pub | sudo tee -a /root/.ssh/authorized_keys
 fi
-

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
+set -eux
 RELEASE_IMAGE="registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
 if [ ! -f /.bootstrap.complete ]; then
-  yum install -y podman systemd-journal-gateway
+  yum install -y crio origin-node --no-gpgcheck
   podman pull "${RELEASE_IMAGE}"
   MCO_IMAGE=$(podman run --rm --net=host -ti ${RELEASE_IMAGE} image machine-config-daemon)
-  podman pull ${MCO_IMAGE}
+  podman pull "${MCO_IMAGE}"
   podman run --privileged --rm \
     -v /ocp:/ocp \
     -v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd \
-    -ti ${MCO_IMAGE}
+    -ti "${MCO_IMAGE}" \
     start --node-name ostest-bootstrap --once-from /ocp/bootstrap.ign
 fi

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+RELEASE_IMAGE="registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+if [ ! -f /.bootstrap.complete ]; then
+  yum install -y podman systemd-journal-gateway
+  podman pull "${RELEASE_IMAGE}"
+  MCO_IMAGE=$(podman run --rm --net=host -ti ${RELEASE_IMAGE} image machine-config-daemon)
+  podman pull ${MCO_IMAGE}
+  podman run --privileged --rm \
+    -v /ocp:/ocp \
+    -v /:/rootfs -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd \
+    -ti ${MCO_IMAGE}
+    start --node-name ostest-bootstrap --once-from /ocp/bootstrap.ign
+fi

--- a/bootstrap/prepare-bootstrap.service
+++ b/bootstrap/prepare-bootstrap.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Prepare bootstrap node
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/sh /usr/local/bin/bootstrap.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/common.sh
+++ b/common.sh
@@ -40,7 +40,6 @@ export RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
 # doesn't work - probably we need to download both as the
 # -openstack one may be needed for the baremetal nodes so we get
 # config drive support, or perhaps a completely new image?
-export RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-qemu.qcow2"
 export RHCOS_IMAGE_FILENAME_OPENSTACK="${RHCOS_IMAGE_NAME}-openstack.qcow2"
 
 # Log output automatically

--- a/get_rhcos_image.sh
+++ b/get_rhcos_image.sh
@@ -3,10 +3,6 @@ set -xe
 
 source common.sh
 
-if [ ! -f "$RHCOS_IMAGE_FILENAME" ]; then
-    curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
-fi
-
 if [ ! -f "${RHCOS_IMAGE_FILENAME_OPENSTACK}" ]; then
     curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME_OPENSTACK}".gz
 fi

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -4,7 +4,7 @@ set -e
 
 source ocp_install_env.sh
 
-$GOPATH/src/github.com/openshift/installer/bin/openshift-install --log-level=debug --dir ocp destroy cluster || true
+sudo podman rm -f ostest-bootstrap || true
 
 rm -rf ocp
 


### PR DESCRIPTION
This removes the need for bootstrap VM and downloading an extra RHCOS image.
Instead of running RHCOS VM and provisioning it using bootstrap VM it does the following:

* Installs podman
* Determines MCD image name - pulls release image, uses `image machine-config-daemon` subcommand to get MCD pullspec
* Runs a CentOS systemd command in an unprivileged container with host network, mounting some directories from host and preparing container storage as a tmpfs
* Copies a bootstrap node preparation script (`bootstrap/bootstrap.sh`) and starts it as a systemd service (`bootstrap/prepare-bootstrap.service`)
* Bootstrap script would install `podman` and `systemd-journal-gateway` (required to setup RHCOS) inside CentOS container
* Boostrap script would pull MCD imagem run it and pass `boostrap.ign` file there.
* MCD would parse it and apply changes there, as if it was a RHCOS image and Ignition was passed on boot.
* After MCD is done, it would attempt to reboot the 'machine', fail and exit with error. `05_deploy_bootstrap_vm.sh` script would restart the container.
* Systemd inside bootstrap container would pick up new systemd services  - most notably bootkube - and run them.
* User machine should now be used as a bootstrap IP

This is, of course, very experimental and should not be merged yet.

TODO:
* [x] Template bootstrap.sh script to pass different MCD image
* [x] Avoid installing podman in a plain CentOS container - prepare a pre-installed version of it
* [ ] Teach MCD to avoid reboot attempt