### PR TITLE
Reload NetworkManager instead of restarting

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -40,4 +40,4 @@ sudo iptables -I INPUT -i virbr0 -p udp -m udp --dport 6230:6235 -j ACCEPT
 # Switch NetworkManager to internal DNS
 sudo mkdir -p /etc/NetworkManager/conf.d/
 sudo crudini --set /etc/NetworkManager/conf.d/dnsmasq.conf main dns dnsmasq
-sudo systemctl restart NetworkManager
+sudo systemctl reload NetworkManager

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -40,4 +40,4 @@ sudo iptables -I INPUT -i virbr0 -p udp -m udp --dport 6230:6235 -j ACCEPT
 # Switch NetworkManager to internal DNS
 sudo mkdir -p /etc/NetworkManager/conf.d/
 sudo crudini --set /etc/NetworkManager/conf.d/dnsmasq.conf main dns dnsmasq
-sudo systemctl reload NetworkManager
+sudo systemctl restart NetworkManager

--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -96,7 +96,7 @@ done
 IP=$(domain_net_ip ${CLUSTER_NAME}-bootstrap default)
 echo "addn-hosts=/etc/hosts.openshift" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
 echo "${IP} ${CLUSTER_NAME}-api.${BASE_DOMAIN}" | sudo tee /etc/hosts.openshift
-sudo systemctl restart NetworkManager
+sudo systemctl reload NetworkManager
 
 # Wait for ssh to start
 while ! ssh -o "StrictHostKeyChecking=no" core@$IP id ; do sleep 5 ; done


### PR DESCRIPTION
Restarting NetworkManager may cause network issues.
Better to reload instead.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>