### PR TITLE
Download ironic-inspector container and allow introspection to run

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -42,7 +42,7 @@ fi
 sudo yum -y update
 
 # make sure additional requirments are installed
-sudo yum install -y bind-utils ansible python-netaddr python-virtualbmc libvirt libvirt-devel libvirt-daemon-kvm qemu-kvm virt-install jq python-ironicclient python-openstackclient
+sudo yum install -y bind-utils ansible python-netaddr python-virtualbmc libvirt libvirt-devel libvirt-daemon-kvm qemu-kvm virt-install jq python-ironicclient python-ironic-inspector-client python-openstackclient
 
 if [ ! -f $HOME/.ssh/id_rsa.pub ]; then
     ssh-keygen -f ~/.ssh/id_rsa -P ""

--- a/ironic/dnsmasq.conf
+++ b/ironic/dnsmasq.conf
@@ -5,7 +5,7 @@ tftp-root=/tftpboot
 
 dhcp-match=ipxe,175
 # Client is already running iPXE; move to next stage of chainloading
-dhcp-boot=tag:ipxe,http://172.22.0.1/boot.ipxe
+dhcp-boot=tag:ipxe,http://172.22.0.1/dualboot.ipxe
 
 # Note: Need to test EFI booting
 dhcp-match=set:efi,option:client-arch,7

--- a/ironic/dualboot.ipxe
+++ b/ironic/dualboot.ipxe
@@ -1,0 +1,22 @@
+#!ipxe
+
+# NOTE(lucasagomes): Loop over all network devices and boot from
+# the first one capable of booting. For more information see:
+# https://bugs.launchpad.net/ironic/+bug/1504482
+set netid:int32 -1
+:loop
+inc netid 
+isset ${net${netid}/mac} || chain pxelinux.cfg/${mac:hexhyp} || goto inspector 
+echo Attempting to boot from MAC ${net${netid}/mac:hexhyp}
+chain pxelinux.cfg/${net${netid}/mac:hexhyp} || goto loop 
+
+# If no networks configured to boot then introspect first valid one
+:inspector
+chain inspector.ipxe || goto loop_done
+
+:loop_done
+echo PXE boot failed! No configuration found for any of the present NICs
+echo and could not find inspector.ipxe to use as fallback.
+echo Press any key to reboot...
+prompt --timeout 180
+reboot

--- a/ironic/inspector.ipxe
+++ b/ironic/inspector.ipxe
@@ -1,0 +1,9 @@
+#!ipxe
+
+
+:retry_boot
+echo In inspector.ipxe
+imgfree
+kernel --timeout 60000 http://172.22.0.1/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://172.22.0.1:5050/v1/continue ipa-inspection-collectors=default,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+initrd --timeout 60000 http://172.22.0.1/images/ironic-python-agent.initramfs || goto retry_boot
+boot


### PR DESCRIPTION
This gets the the ironic-inspector container and starts it. It also
changes the boot.ipxe file used for deployment to include
inspector.ipxe for introspection. If a deployment is not
being done, i.e. Ironic has not created a file in
/var/www/html/pxelinux.cfg/<MAC>, then the inspector.ipxe
file will be chainloaded to cause the IPA to run introspection
and return data to Ironic Inspector.

To access the Ironic Inspector API use:
export OS_TOKEN=fake-token
export OS_URL=http://ostest-api.test.metalkube.org:5050/