### PR TITLE
Edit interface name in master's etcd discovery

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -11,7 +11,7 @@ sudo yum -y update
 sudo yum -y install epel-release --enablerepo=extras
 sudo yum -y install curl vim-enhanced wget python-pip patch psmisc figlet golang dnsmasq NetworkManager crudini
 
-sudo pip install lolcat json-patch
+sudo pip install lolcat json-patch yq
 
 # for tripleo-repos install
 sudo yum -y install python-setuptools python-requests

--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -143,4 +143,27 @@ ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman run \
 # Create a master_nodes.json file
 jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee ocp/master_nodes.json
 
+MASTER_INTERFACE="eth1"
+
+# Fix etcd discovery on bootstrap
+rm -rf ocp/machineconfigs
+mkdir -p ocp/machineconfigs/temp
+# Find master machine config name
+while [ -z $(ssh -o StrictHostKeyChecking=no "core@$IP" sudo ls /etc/mcs/bootstrap/machine-configs/master*) ]; do sleep 5; done
+
+MASTER_CONFIG=$(ssh -o StrictHostKeyChecking=no "core@$IP" sudo ls /etc/mcs/bootstrap/machine-configs/master*)
+ssh -o "StrictHostKeyChecking=no" "core@$IP" sudo cat "${MASTER_CONFIG}" > ocp/machineconfigs/temp/master.yaml
+# Extract etcd-member.yaml part
+yq -r ".spec.config.storage.files[] | select(.path==\"/etc/kubernetes/manifests/etcd-member.yaml\") | .contents.source" ocp/machineconfigs/temp/master.yaml | sed 's;data:,;;' > ocp/machineconfigs/temp/etcd-member.urlencode
+# URL decode
+cat ocp/machineconfigs/temp/etcd-member.urlencode | urldecode > ocp/machineconfigs/etcd-member.yaml
+# Add a new param to args in discovery container
+sed -i "s;- \"run\";- \"run\"\\n    - \"--if-name=${MASTER_INTERFACE}\";g" ocp/machineconfigs/etcd-member.yaml
+# URL encode yaml
+cat ocp/machineconfigs/etcd-member.yaml | jq -sRr @uri > ocp/machineconfigs/temp/etcd-member.urlencode_updated
+# Replace etcd-member contents in the yaml
+sed "s;$(cat ocp/machineconfigs/temp/etcd-member.urlencode);$(cat ocp/machineconfigs/temp/etcd-member.urlencode_updated);g" ocp/machineconfigs/temp/master.yaml > ocp/machineconfigs/master.yaml
+# Copy the changed file back to bootstrap
+cat ocp/machineconfigs/master.yaml | ssh -o "StrictHostKeyChecking=no" "core@$IP" sudo dd of="${MASTER_CONFIG}"
+
 echo "You can now ssh to \"$IP\" as the core user"

--- a/utils.sh
+++ b/utils.sh
@@ -95,3 +95,7 @@ function network_ip() {
     fi
     echo "$ip"
 }
+
+function urldecode() {
+  echo -e "$(sed 's/+/ /g;s/%\(..\)/\\x\1/g;')"
+}


### PR DESCRIPTION
etcd discovery container defaults to `eth0` interface to detect etcd IP and compare it with etcd SRV record.

This PR would pull MCS config, extract `etcd-member` k8s manifest, add `--if-name` argument to the container, pack it back and restart MCS to serve new ignition files to masters.

In the future this will be reverted and interface name would be a part of platform config, set in the installer. MCS would read this and automatically set `args` when assets are being generated