### PR TITLE
Allowing root_disk and instack.json to be set in advance.

### DIFF
--- a/06_deploy_masters.sh
+++ b/06_deploy_masters.sh
@@ -2,6 +2,7 @@
 
 set -eux
 source utils.sh
+source common.sh
 
 # Note This logic will likely run in a container (on the bootstrap VM)
 # for the final solution, but for now we'll prototype the workflow here
@@ -29,8 +30,7 @@ cp ocp/master.ign configdrive/openstack/latest/user_data
 for node in $(jq -r .nodes[].name $instack); do
 
   # FIXME(shardy) we should parameterize the image and checksum (or calculate the latter)
-  # Change to sda if using BM
-  openstack baremetal node set $node --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack.qcow2 --instance-info image_checksum=2a38fafe0b9465937955e4d054b8db3a --instance-info root_gb=25 --property root_device='{"name": "/dev/vda"}'
+  openstack baremetal node set $node --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack.qcow2 --instance-info image_checksum=2a38fafe0b9465937955e4d054b8db3a --instance-info root_gb=25  --property root_device="{\"name\": \"$ROOT_DISK\"}"
   openstack baremetal node manage $node --wait
   openstack baremetal node provide $node --wait
   openstack baremetal node deploy --config-drive configdrive $node

--- a/common.sh
+++ b/common.sh
@@ -11,8 +11,10 @@ EXT_IF=${EXT_IF:-}
 PRO_IF=${PRO_IF:-}
 # Internal interface, to bridge virbr0
 INT_IF=${INT_IF:-}
+#Root disk to deploy coreOS - use /dev/sda on BM
+ROOT_DISK=${ROOT_DISK:="/dev/vda"}
 
-if [ -z "$CONFIG" ]; then  
+if [ -z "${CONFIG:-}" ]; then  
     # See if there's a config_$USER.sh in the SCRIPTDIR
     if [ -f ${SCRIPTDIR}/config_${USER}.sh ]; then
         echo "Using CONFIG ${SCRIPTDIR}/config_${USER}.sh"


### PR DESCRIPTION
Adding a valirable that if set is used as the root_device.
Making it possible to use a prepared instack.json. Previously
it was always trying to create one for libvirt based setup and
the MAC addresses in it didn't match the real ones on BM nodes.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>