### PR TITLE
WIP Masters should be part of DNS round-robin

### DIFF
--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -93,8 +93,12 @@ done
 
 # NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
 IP=$(domain_net_ip ${CLUSTER_NAME}-bootstrap baremetal)
-API_IP=$(dig +noall +answer "${CLUSTER_NAME}-api.${BASE_DOMAIN}" @$(network_ip baremetal) | awk '{print $NF}')
-echo "address=/${CLUSTER_NAME}-api.${BASE_DOMAIN}/${API_IP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+echo "addn-hosts=/etc/hosts.openshift" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
+echo "${IP} ${CLUSTER_NAME}-api.${BASE_DOMAIN}" | sudo tee /etc/hosts.openshift
+for i in 0 1 2; do
+  MASTER_API=$(dig +noall +answer "${CLUSTER_NAME}-etcd-${i}.${BASE_DOMAIN}" @$(network_ip baremetal) | awk '{print $NF}')
+  echo "${MASTER_API} ${CLUSTER_NAME}-api.${BASE_DOMAIN}" | sudo tee -a /etc/hosts.openshift
+done
 sudo systemctl reload NetworkManager
 
 # Wait for ssh to start
@@ -112,7 +116,7 @@ if [ ! -e images/redhat-coreos-maipo-47.284-openstack_dualdhcp.qcow2 ] ; then
     mkdir -p /tmp/mnt
     sudo kpartx -a /dev/$LOOPBACK
     sudo mount /dev/mapper/${LOOPBACK}p1 /tmp/mnt
-    sudo sed -i -e 's/ip=eth0:dhcp/ip=eth0:dhcp ip=eth1:dhcp/g' /tmp/mnt/grub2/grub.cfg 
+    sudo sed -i -e 's/ip=eth0:dhcp/ip=eth0:dhcp ip=eth1:dhcp/g' /tmp/mnt/grub2/grub.cfg
     sudo umount /tmp/mnt
     sudo kpartx -d /dev/${LOOPBACK}
     sudo losetup -d /dev/${LOOPBACK}

--- a/tripleo-quickstart-config/roles/common/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/common/defaults/main.yml
@@ -178,9 +178,6 @@ networks:
           port: 2380
           target: "{{ cluster_name }}-etcd-2.{{ base_domain }}"
       hosts:
-        - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
-          hostnames:
-            - "{{ cluster_name }}-api"
         - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
           hostnames:
             - "{{ cluster_name }}-dns"


### PR DESCRIPTION
`-api` should point to bootstrap node and masters, this address would be used for control plane. Initially it would start on bootstrap and then prepare 'real' masters on master/etcd nodes

TODO:
* [ ] Modify `baremetal.addnhosts` instead