### PR TITLE
Allow disabling master/worker VMs for baremetal testing

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -18,6 +18,7 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e @tripleo-quickstart-config/metalkube-nodes.yml \
     -e "local_working_dir=$HOME/.quickstart" \
     -e "virthost=$HOSTNAME" \
+    -e "platform=$NODES_PLATFORM" \
     -e @config/environments/dev_privileged_libvirt.yml \
     -i tripleo-quickstart-config/metalkube-inventory.ini \
     -b -vvv tripleo-quickstart-config/metalkube-setup-playbook.yml \

--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -141,6 +141,6 @@ ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman run \
     "${IRONIC_INSPECTOR_IMAGE}"
 
 # Create a master_nodes.json file
-jq '.nodes[0:3] | {nodes: .}' "${WORKING_DIR}/ironic_nodes.json" | tee ocp/master_nodes.json
+jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee ocp/master_nodes.json
 
 echo "You can now ssh to \"$IP\" as the core user"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ from tripleo-quickstart here.
 
 # Instructions
 
+## Configuration
+
+Make a copy of the `config_example.sh` to `config_$USER.sh`, and set the `PULL_SECRET`
+variable to the secret obtained from cloud.openshift.com.
+
+For baremetal test setups where you don't require the VM fake-baremetal nodes, you may also
+set `NODES_FILE` to reference a manually created json file with the node details, and
+`NODES_PLATFORM` which can be set to e.g "baremetal" to disable the libvirt master/worker
+node setup. See common.sh for other variables that can be overridden.
+
 ## Installation
 
 For a new setup, run:

--- a/common.sh
+++ b/common.sh
@@ -2,7 +2,7 @@
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 USER=`whoami`
-WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
+
 # Additional DNS
 ADDN_DNS=${ADDN_DNS:-}
 # External interface for routing traffic through the host
@@ -27,6 +27,10 @@ if [ -z "${CONFIG:-}" ]; then
 fi
 source $CONFIG
 cat $CONFIG
+
+WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
+NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
+NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
 
 if [ -z "$PULL_SECRET" ]; then
   echo "No valid PULL_SECRET set in ${CONFIG}"

--- a/tripleo-quickstart-config/metalkube-setup-playbook.yml
+++ b/tripleo-quickstart-config/metalkube-setup-playbook.yml
@@ -6,8 +6,15 @@
   hosts: virthost
   connection: local
   gather_facts: true
-  roles:
-    - environment/setup
-    - libvirt/setup/overcloud
-    - virtbmc
+  tasks:
+    - import_role:
+        name: common
+    - import_role:
+        name: environment/setup
+    - import_role:
+        name: libvirt/setup/overcloud
+      when: platform == "libvirt"
+    - import_role:
+        name: virtbmc
+      when: platform == "libvirt"
 


### PR DESCRIPTION
When testing with real baremetal master/worker nodes we only
need the bootstrap VM, so we can disable some of the quickstart
roles by setting "NODES_PLATFORM" to something other than "libvirt"
which is the default.

NODES_FILE can also be overridden to point to your manually created
alternative to $WORKING_DIR/ironic_nodes.json (or you can just
copy it to that location).

This was created following conversation in https://github.com/metalkube/dev-scripts/pull/67