### PR TITLE
Rename instack to MASTER_NODES_FILE

### DIFF
--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -141,6 +141,6 @@ ssh -o "StrictHostKeyChecking=no" core@$IP sudo podman run \
     "${IRONIC_INSPECTOR_IMAGE}"
 
 # Create a master_nodes.json file
-jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee ocp/master_nodes.json
+jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"
 
 echo "You can now ssh to \"$IP\" as the core user"

--- a/06_deploy_masters.sh
+++ b/06_deploy_masters.sh
@@ -6,7 +6,6 @@ source common.sh
 
 # Note This logic will likely run in a container (on the bootstrap VM)
 # for the final solution, but for now we'll prototype the workflow here
-instack="ocp/master_nodes.json"
 export OS_TOKEN=fake-token
 export OS_URL=http://ostest-api.test.metalkube.org:6385/
 
@@ -17,17 +16,17 @@ wait_for_json ironic \
 
 # Clean previously env
 nodes=$(openstack baremetal node list)
-for node in $(jq -r .nodes[].name ${instack}); do
+for node in $(jq -r .nodes[].name ${MASTER_NODES_FILE}); do
   if [[ $nodes =~ $node ]]; then
     openstack baremetal node undeploy $node --wait || true
     openstack baremetal node delete $node
   fi
 done
 
-openstack baremetal create $instack
+openstack baremetal create $MASTER_NODES_FILE
 mkdir -p configdrive/openstack/latest
 cp ocp/master.ign configdrive/openstack/latest/user_data
-for node in $(jq -r .nodes[].name $instack); do
+for node in $(jq -r .nodes[].name $MASTER_NODES_FILE); do
 
   # FIXME(shardy) we should parameterize the image
   openstack baremetal node set $node --instance-info image_source=http://172.22.0.1/images/redhat-coreos-maipo-47.284-openstack_dualdhcp.qcow2 --instance-info image_checksum=$(md5sum images/redhat-coreos-maipo-47.284-openstack_dualdhcp.qcow2 | awk '{print $1}') --instance-info root_gb=25 --property root_device="{\"name\": \"$ROOT_DISK\"}"
@@ -35,7 +34,7 @@ for node in $(jq -r .nodes[].name $instack); do
   openstack baremetal node provide $node --wait
 done
 
-for node in $(jq -r .nodes[].name $instack); do
+for node in $(jq -r .nodes[].name $MASTER_NODES_FILE); do
   openstack baremetal node deploy --config-drive configdrive $node
 done
 # FIXME(shardy) we should wait for the node deploy to complete (or fail)

--- a/common.sh
+++ b/common.sh
@@ -31,6 +31,7 @@ cat $CONFIG
 WORKING_DIR=${WORKING_DIR:-"/opt/dev-scripts"}
 NODES_FILE=${NODES_FILE:-"${WORKING_DIR}/ironic_nodes.json"}
 NODES_PLATFORM=${NODES_PLATFORM:-"libvirt"}
+MASTER_NODES_FILE=${MASTER_NODES_FILE:-"ocp/master_nodes.json"}
 
 if [ -z "$PULL_SECRET" ]; then
   echo "No valid PULL_SECRET set in ${CONFIG}"


### PR DESCRIPTION
This should avoid confusion since instack is a legacy TripleO thing,
also make MASTER_NODES_FILE overridable so folks can do that
for baremetal testing as an alternative to NODES_FILE if they wish.