### PR TITLE
Also remove ocp/install-config.yaml during cleanup

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -10,3 +10,4 @@ VOL_POOL=$(sudo virsh vol-pool "/var/lib/libvirt/images/${CLUSTER_NAME}-bootstra
 sudo virsh vol-delete "${CLUSTER_NAME}-bootstrap.ign" --pool "${VOL_POOL}"
 rm -rf ocp
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf
+rm -f ocp/install-config.yaml


### PR DESCRIPTION
In situations where PULL_SECRET is either bad or broken, the
contents of this will still be written to install-config.yaml.
It's still assumed to be valid.  Since we source config_*.sh
anyway before running any of the top-level cleanups, we can
expect to just write this value to ocp/install-config anyway.