### PR TITLE
Don't generate clusterID

### DIFF
--- a/05_deploy_bootstrap_vm.sh
+++ b/05_deploy_bootstrap_vm.sh
@@ -13,11 +13,9 @@ source utils.sh
 # qemu endpoint configurable?
 if [ ! -d ocp ]; then
     mkdir -p ocp
-    export CLUSTER_ID=$(uuidgen --random)
     cat > ocp/install-config.yaml << EOF
 apiVersion: v1beta1
 baseDomain: ${BASE_DOMAIN}
-clusterID:  ${CLUSTER_ID}
 machines:
 - name:     master
   platform: {}


### PR DESCRIPTION
Since 0.10.0, clusterID is no longer part of install-config.yaml

See openshift/installer#1057