### PR TITLE
Tolerate failure in *_cleanup.sh

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xe
+set -x
 
 source common.sh
 

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -x
 
 source ocp_install_env.sh
 


### PR DESCRIPTION
This means we still clean things up if e.g the bootstrap VM is still
defined but not running.