### PR TITLE
Remove provisioning nic from the kernel command line

### DIFF
--- a/ignition_patches/master/02_noneed_prov_nic.json
+++ b/ignition_patches/master/02_noneed_prov_nic.json
@@ -1,0 +1,27 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/config/systemd/units/-",
+    "value": {
+      "contents": "[Unit]\nDescription=Delete provisioning nic from the kernel command line so it can't stall dracut netowrking\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/rm-provision-nic.sh\n[Install]\nWantedBy=multi-user.target\n",
+      "enabled": true,
+      "name": "rm-provision-nic.service"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/config/storage/files/-",
+    "value": {
+      "filesystem": "root",
+      "path": "/usr/local/bin/rm-provision-nic.sh",
+      "user": {
+        "name": "root"
+      },
+      "contents": {
+        "source": "data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKClBST1ZERVY9JChpcCByb3V0ZSBnZXQgdG8gMTcyLjIyLjAuMSB8IGF3ayAnL2Rldi97cHJpbnQgJDN9JykKc3VkbyBzZWQgLWkub2xkIC1lICJzLyBpcD0ke1BST1ZERVZ9OmRoY3AvL2ciIC9ib290L2dydWIyL2dydWIuY2ZnCnN5bmMK",
+        "verification": {}
+      },
+      "mode": 365
+    }
+  }
+]


### PR DESCRIPTION
Having it there results in dracut attempting to dchp on boot.
This doesn't work and stalls the boot process once ironic is gone away.