### PR TITLE
Add firewall rule to allow IPA access to Ironic API

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -39,6 +39,11 @@ if [ ! -e /etc/sysconfig/network-scripts/ifcfg-brovc ] ; then
     sudo ifup brovc
 fi
 
+# Add firewall rule to ensure the IPA ramdisk can reach the Ironic API on the host
+if ! sudo iptables -C INPUT -i brovc -p tcp -m tcp --dport 6385 -j ACCEPT; then
+    sudo iptables -I INPUT -i brovc -p tcp -m tcp --dport 6385 -j ACCEPT
+fi
+
 # Workaround so that the dracut network module does dhcp on eth0 & eth1
 RHCOS_IMAGE_FILENAME_RAW="${RHCOS_IMAGE_FILENAME_OPENSTACK}.raw"
 if [ ! -e "$IRONIC_DATA_DIR/html/images/$RHCOS_IMAGE_FILENAME_DUALDHCP" ] ; then


### PR DESCRIPTION
This was failing for me, with a misleading "no route to host" error
from the IPA urllib code (the route was fine, but the firewall
blocked the port)

So, ensure we always open up this port for traffic over the brovc
bridge from the master/worker VMs to Ironic running on the host.