### PR TITLE
Fix wait_for_json

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 function apply_ignition_patches() {
 local kind
 local target
@@ -194,6 +196,7 @@ function wait_for_json() {
             echo "\nTimed out waiting for $name"
             return 1
         fi
+        sleep 5
     done
     echo " Success!"
     return 0


### PR DESCRIPTION
even if the curl in wait_for_json fails the command returns success
as the "jq ." doesn't fail. This function presumably should be
running with pipefail set to work properly. Also add a sleep to
slow it down a bit.