### PR TITLE
Create link to the latest RHCOS image

### DIFF
--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -29,7 +29,7 @@ cp ocp/master.ign configdrive/openstack/latest/user_data
 for node in $(jq -r .nodes[].name $MASTER_NODES_FILE); do
 
   # FIXME(shardy) we should parameterize the image
-  openstack baremetal node set $node --instance-info "image_source=http://172.22.0.1/images/$RHCOS_IMAGE_FILENAME_DUALDHCP" --instance-info image_checksum=$(md5sum "$IRONIC_DATA_DIR/html/images/$RHCOS_IMAGE_FILENAME_DUALDHCP" | awk '{print $1}') --instance-info root_gb=25 --property root_device="{\"name\": \"$ROOT_DISK\"}"
+  openstack baremetal node set $node --instance-info "image_source=http://172.22.0.1/images/$RHCOS_IMAGE_FILENAME_LATEST" --instance-info image_checksum=$(curl http://172.22.0.1/images/$RHCOS_IMAGE_FILENAME_LATEST.md5sum) --instance-info root_gb=25 --property root_device="{\"name\": \"$ROOT_DISK\"}"
   openstack baremetal node manage $node --wait
   openstack baremetal node provide $node --wait
 done

--- a/common.sh
+++ b/common.sh
@@ -58,6 +58,7 @@ export RHCOS_IMAGE_NAME="redhat-coreos-maipo-${RHCOS_IMAGE_VERSION}"
 export RHCOS_IMAGE_FILENAME="${RHCOS_IMAGE_NAME}-qemu.qcow2"
 export RHCOS_IMAGE_FILENAME_OPENSTACK="${RHCOS_IMAGE_NAME}-openstack.qcow2"
 export RHCOS_IMAGE_FILENAME_DUALDHCP="${RHCOS_IMAGE_NAME}-dualdhcp.qcow2"
+export RHCOS_IMAGE_FILENAME_LATEST="redhat-coreos-maipo-latest.qcow2"
 
 # Ironic vars
 export IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metalkube/metalkube-ironic"}


### PR DESCRIPTION
Create a link(redhat-coreos-maipo-latest.qcow2) pointing to the
the RHCOS image that we should be using. Also precalcualte the
md5sum of this image and expose it over http. This will allow
a client to reference the image to deploy and get its md5sum,
without having to download the data to calculate it.