### PR TITLE
fix OS_URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For manual debugging via openstackclient, you can use the following:
 
 ```
 export OS_TOKEN=fake-token
-export OS_URL=http://api.ostest.test.metalkube.org:6385/
+export OS_URL=http://localhost:6385/
 openstack baremetal node list
 ...
 ```


### PR DESCRIPTION
The OS_URL value in the readme points to the OpenShift API not Ironic.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>