### PR TITLE
Cleanup ssh known hosts in ocp_cleanup.sh

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -10,3 +10,6 @@ VOL_POOL=$(sudo virsh vol-pool "/var/lib/libvirt/images/${CLUSTER_NAME}-bootstra
 sudo virsh vol-delete "${CLUSTER_NAME}-bootstrap.ign" --pool "${VOL_POOL}"
 rm -rf ocp
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf
+
+# Cleanup ssh keys for baremetal network
+sed -i "/^192.168.111/d" /home/$USER/.ssh/known_hosts


### PR DESCRIPTION
This is helpful to avoid warnings when ssh is used manually
from the host to access the deployed nodes.

We might also want to clean this in 07_deploy_masters.sh when
we detect that the VIP has failed over from the bootstrap node,
but I've not considered that in this patch.