### PR TITLE
Also cleanup api ssh known_hosts entry

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -13,3 +13,4 @@ sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf
 
 # Cleanup ssh keys for baremetal network
 sed -i "/^192.168.111/d" /home/$USER/.ssh/known_hosts
+sed -i "/^api.${CLUSTER_DOMAIN}/d" /home/$USER/.ssh/known_hosts


### PR DESCRIPTION
Some scripts access the cluster via the vip so we also need to clean
this to avoid ssh warnings when re-running the scripts

We may also want to clean this after the VIP fails over from the
bootstrap node, but I've not considered that in this patch