### PR TITLE
manifests: Add CNV (kubevirt) manifests

### DIFF
--- a/manifests/10_cnv_kubevirt_op.yaml
+++ b/manifests/10_cnv_kubevirt_op.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: kubevirt
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  version: v1alpha3
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:operator
+  labels:
+    operator.kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - kubevirts
+    verbs:
+      - get
+      - delete
+      - create
+      - update
+      - patch
+      - list
+      - watch
+      - deletecollection
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kubevirt-operator
+  namespace: kubevirt
+  labels:
+    operator.kubevirt.io: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-operator
+  namespace: kubevirt
+  labels:
+    operator.kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-operator
+    namespace: kubevirt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: virt-operator
+  namespace: kubevirt
+  labels:
+    operator.kubevirt.io: "virt-operator"
+spec:
+  replicas: 1
+  selector:
+      matchLabels:
+        operator.kubevirt.io: virt-operator
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: |
+                  [
+                    {
+                      "key": "CriticalAddonsOnly",
+                      "operator": "Exists"
+                    }
+                  ]
+      labels:
+        operator.kubevirt.io: virt-operator
+        prometheus.kubevirt.io: ""
+    spec:
+      serviceAccountName: kubevirt-operator
+      containers:
+        - name: virt-operator
+          image: &image docker.io/kubevirt/virt-operator:v0.15.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - virt-operator
+            - --port
+            - "8443"
+            - -v
+            - "2"
+          ports:
+            - containerPort: 8443
+              name: "metrics"
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: "metrics"
+              path: "/metrics"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+            - name: OPERATOR_IMAGE
+              value: *image
+      securityContext:
+        runAsNonRoot: true

--- a/manifests/11_cnv_kubevirt_cr.yaml
+++ b/manifests/11_cnv_kubevirt_cr.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kubevirt.io/v1alpha3
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  imagePullPolicy: IfNotPresent

--- a/manifests/12_cnv_kubevirt_config.yaml
+++ b/manifests/12_cnv_kubevirt_config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: kubevirt
+data:
+  debug.useEmulation: "true"

--- a/manifests/README.cnv
+++ b/manifests/README.cnv
@@ -30,6 +30,11 @@ After creation you can wait for the application readiness with:
 ```
 
 
+### Running a VM
+
+Apply this config https://github.com/kubevirt/demo/blob/master/manifests/vm.yaml
+
+
 ## CDI
 
 TBD

--- a/manifests/README.cnv
+++ b/manifests/README.cnv
@@ -1,0 +1,30 @@
+# CNV Manifests
+
+## KubeVirt
+
+Done as described here:
+
+https://kubevirt.io/user-guide/docs/latest/administration/intro.html#2-alternative-flow-aka-operator-flow
+
+Created using:
+
+```
+VERSION=v0.15.0
+curl -Lo 10_cnv_kubevirt_op.yaml https://github.com/kubevirt/kubevirt/releases/download/$VERSION/kubevirt-operator.yaml
+curl -Lo 11_cnv_kubevirt_cr.yaml https://github.com/kubevirt/kubevirt/releases/download/$VERSION/kubevirt-cr.yaml
+```
+
+After creation you can wait for the application readiness with:
+
+```
+ kubectl wait kv kubevirt --for condition=Ready
+```
+
+
+## CDI
+
+TBD
+
+## Network
+
+TBD

--- a/manifests/README.cnv
+++ b/manifests/README.cnv
@@ -12,6 +12,15 @@ Created using:
 VERSION=v0.15.0
 curl -Lo 10_cnv_kubevirt_op.yaml https://github.com/kubevirt/kubevirt/releases/download/$VERSION/kubevirt-operator.yaml
 curl -Lo 11_cnv_kubevirt_cr.yaml https://github.com/kubevirt/kubevirt/releases/download/$VERSION/kubevirt-cr.yaml
+cat > 12_cnv_kubevirt_config.yaml <<EOY
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: kubevirt
+data:
+  debug.useEmulation: "true"
+EOY
 ```
 
 After creation you can wait for the application readiness with:

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,14 @@
+A number of manifests which will be deployed during installation.
+
+Assumption is that the list of sorted manifests is applicable using:
+
+```bash
+for MANIFEST in $(ls -1 | sort -h);
+do
+  kubectl apply -f $MANIFEST
+done
+```
+
+> **Important note:** We do not assume that all manifests can be applied in one
+> go using `kubectlapply -f .` as some manfiests will be depending on others,
+> i.e. a manifest introducing a CRD is needed before the CR can be created.

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -10,5 +10,5 @@ done
 ```
 
 > **Important note:** We do not assume that all manifests can be applied in one
-> go using `kubectlapply -f .` as some manfiests will be depending on others,
+> go using `kubectl apply -f .` as some manifests will depend on others,
 > i.e. a manifest introducing a CRD is needed before the CR can be created.


### PR DESCRIPTION
This change adds the kubevirt manifests.

This is not all of the CNV manifests. But a start.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>