### PR TITLE
Install additional CNI / device network plugins

### DIFF
--- a/manifests/120_cni_plugins.yaml
+++ b/manifests/120_cni_plugins.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-cni-plugins-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: cni-plugins
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: cni-plugins
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: cni-plugins
+        image: quay.io/kubevirt/cni-default-plugins:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          cp -rf /usr/src/containernetworking/plugins/bin/* /opt/cni/bin/
+          echo "Entering sleep... (success)"
+          sleep infinity
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cnibin
+          mountPath: /opt/cni/bin
+      volumes:
+      - name: cnibin
+        hostPath:
+          path: /opt/cni/bin

--- a/manifests/121_sriovdp.yaml
+++ b/manifests/121_sriovdp.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriov-nodes-config
+  namespace: kube-system
+data:
+  fallback-config: |
+    {
+        "resourceList":
+        [
+            {
+                "resourceName": "sriov",
+                "rootDevices": [],
+                "sriovMode": true,
+                "deviceType": "vfio"
+            }
+        ]
+    }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-device-plugin
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-device-plugin-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriovdp
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: sriovdp
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: sriov-device-plugin
+      initContainers:
+      - name: config-container
+        image: quay.io/booxter/sriov-device-plugin:latest
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - |
+          if [ -f /etc/sriov-nodes-config/$NODE_NAME ]; then
+            config_path=/etc/sriov-nodes-config/$NODE_NAME
+          else
+            config_path=/etc/sriov-nodes-config/fallback-config
+          fi
+          cp $config_path /etc/pcidp/config.json
+        volumeMounts:
+        - name: config
+          mountPath: /etc/pcidp
+        - name: configmap
+          mountPath: /etc/sriov-nodes-config
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      containers:
+      - name: kube-sriovdp
+        image: quay.io/booxter/sriov-device-plugin:latest
+        args:
+        - --log-level=10
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - name: devicesock
+          mountPath: /var/lib/kubelet/device-plugins/
+          readOnly: false
+        - name: sysfs
+          mountPath: /sys
+          readOnly: true
+        - name: config
+          mountPath: /etc/pcidp
+          readOnly: true
+      volumes:
+        - name: devicesock
+          hostPath:
+            path: /var/lib/kubelet/device-plugins/
+        - name: sysfs
+          hostPath:
+            path: /sys
+        - name: config
+          hostPath:
+            path: /etc/pcidp
+            type: DirectoryOrCreate
+        - name: configmap
+          configMap:
+            name: sriov-nodes-config

--- a/manifests/122_sriov_crd.yaml
+++ b/manifests/122_sriov_crd.yaml
@@ -1,0 +1,20 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net
+  namespace: kube-system
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+spec:
+  config: '{
+  "type": "sriov",
+  "name": "sriov",
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.56.217.0/24",
+    "routes": [{
+      "dst": "0.0.0.0/0"
+    }],
+    "gateway": "10.56.217.1"
+  }
+}'

--- a/manifests/123_sriov_cni.yaml
+++ b/manifests/123_sriov_cni.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-sriov-cni-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: sriov-cni
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: sriov-cni
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: kube-sriov-cni
+        image: docker.io/nfvpe/sriov-cni:latest
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        volumeMounts:
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+      volumes:
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin

--- a/manifests/124_ovs_cni.yaml
+++ b/manifests/124_ovs_cni.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-ovs-cni-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: ovs-cni
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: ovs-cni
+    spec:
+      serviceAccountName: ovs-cni-marker
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      initContainers:
+      - name: ovs-vsctl
+        command:
+        - /bin/bash
+        - -c
+        - |
+          cp /usr/bin/ovs-vsctl /host/usr/local/bin/_ovs-vsctl
+          echo '#!/bin/sh
+          _ovs-vsctl --db unix:///run/openvswitch/db.sock $@
+          ' > /host/usr/local/bin/ovs-vsctl
+          chmod +x /host/usr/local/bin/ovs-vsctl
+        image: docker.io/openshift/origin-node:latest
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: localbin
+          mountPath: /host/usr/local/bin
+      containers:
+      - name: plugin
+        image: quay.io/kubevirt/ovs-cni-plugin:latest
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+      - name: marker
+        image: quay.io/kubevirt/ovs-cni-marker:latest
+        securityContext:
+          privileged: true
+        args:
+          - -node-name
+          - $(NODE_NAME)
+          - -ovs-socket
+          - unix:///host/run/openvswitch/db.sock
+        volumeMounts:
+          - name: ovs-run
+            mountPath: /host/run/openvswitch
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+      volumes:
+        - name: localbin
+          hostPath:
+            path: /usr/local/bin
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin
+        - name: ovs-run
+          hostPath:
+            path: /run/openvswitch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: ovs-cni-marker-cr
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - get
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: ovs-cni-marker-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ovs-cni-marker-cr
+subjects:
+- kind: ServiceAccount
+  name: ovs-cni-marker
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovs-cni-marker
+  namespace: kube-system

--- a/manifests/README_cnv.md
+++ b/manifests/README_cnv.md
@@ -41,4 +41,14 @@ TBD
 
 ## Network
 
-TBD
+Manifests are based on https://github.com/kubevirt/kubevirt-ansible/tree/master/roles/network-multus/templates
+
+The list is as follows:
+
+```
+120_cni_plugins.yaml
+121_sriovdp.yaml
+122_sriov_crd.yaml
+123_sriov_cni.yaml
+124_ovs_cni.yaml
+```


### PR DESCRIPTION
These are network plugins installed by kubevirt-ansible.

OVS CNI pod needed adjustment in line with
https://github.com/kubevirt/ovs-cni/pull/70 to be able to create ovs-vsctl
executable on CoreOS.