### PR TITLE
Use ssh with ConnectTimeout=5

### DIFF
--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -76,7 +76,7 @@ echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/
 sudo systemctl reload NetworkManager
 
 # Wait for ssh to start
-while ! ssh -o "StrictHostKeyChecking=no" core@$IP id ; do sleep 5 ; done
+while ! $SSH core@$IP id ; do sleep 5 ; done
 
 # Create a master_nodes.json file
 jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"

--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -69,7 +69,7 @@ done
 echo "Master nodes up, you can ssh to the following IPs with core@<IP>"
 sudo virsh net-dhcp-leases baremetal
 
-while [[ ! $(ssh -o StrictHostKeyChecking=no "core@api.${CLUSTER_NAME}.${BASE_DOMAIN}" hostname) =~ master- ]]; do
+while [[ ! $(timeout -k 9 5 $SSH "core@api.${CLUSTER_NAME}.${BASE_DOMAIN}" hostname) =~ master- ]]; do
   echo "Waiting for the master API to become ready..."
   sleep 10
 done

--- a/common.sh
+++ b/common.sh
@@ -28,6 +28,9 @@ fi
 source $CONFIG
 cat $CONFIG
 
+# Use a cloudy ssh that doesn't do Host Key checking
+export SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"
+
 # Connect to system libvirt
 export LIBVIRT_DEFAULT_URI=qemu:///system
 if [ "$USER" != "root" -a "${XDG_RUNTIME_DIR:-}" == "/run/user/0" ] ; then


### PR DESCRIPTION
I've seen the ssh to check if the master API is ready
(in 07_deploy_masters.sh) hang and have to be killed for the
script to move one, presumably this was something to do
with the VIP moving from the bootstrap node to the master.
Add a timeout to all ssh commands to prevent this from happening,
also create a common SSH env variable for all ssh commands.