### PR TITLE
Adding check for failed string in status.

### DIFF
--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -48,7 +48,7 @@ done
 # https://storyboard.openstack.org/#!/story/2005093
 NUM_ACTIVE=$(openstack baremetal node list --fields name --fields provision_state | grep master | grep active | wc -l || echo 0)
 while [ "$NUM_ACTIVE" != "3" ]; do
-  if openstack baremetal node list --fields name --fields provision_state | grep master | grep error; then
+  if openstack baremetal node list --fields name --fields provision_state | grep master | grep -e error -e failed; then
     openstack baremetal node list
     echo "Error detected waiting for baremetal nodes to become active" >&2
     exit 1


### PR DESCRIPTION
Sometimes the status can be "deploy failed" and this
patch adds the check to catch it too. Otherwise the
checking loop doesn't end.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>