### PR TITLE
setup_ironic: Do not copy if src is dst

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -8,7 +8,9 @@ source common.sh
 source get_images.sh
 
 # ironic dnsmasq and ipxe config
-cp ironic/dnsmasq.conf $IRONIC_DATA_DIR/
+if [[ "${PWD}/ironic" != "$IRONIC_DATA_DIR" ]]; then
+    cp ironic/dnsmasq.conf "${IRONIC_DATA_DIR}/dnsmasq.conf"
+fi
 cp ironic/dualboot.ipxe ironic/inspector.ipxe $IRONIC_DATA_DIR/html/
 
 # Either pull or build the ironic images


### PR DESCRIPTION
In case your WORKING DIR is the same directory that has the dev scripts
copying will fail complaining that the source and destination are the
same file. In this case, we should just not copy

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>