### PR TITLE
Allowing access to tftp server.

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -51,6 +51,11 @@ if ! sudo iptables -C INPUT -p tcp --dport 80 -j ACCEPT ; then
     sudo iptables -I INPUT -p tcp --dport 80 -j ACCEPT
 fi
 
+#Allow access to tftp server for pxeboot
+if ! sudo iptables -C INPUT -p udp --dport 69 -j ACCEPT ; then
+    sudo iptables -I INPUT -p udp --dport 69 -j ACCEPT
+fi
+
 # Need to route traffic from the provisioning host.
 if [ "$EXT_IF" ]; then
   sudo iptables -t nat -A POSTROUTING --out-interface $EXT_IF -j MASQUERADE


### PR DESCRIPTION
We need to have port 69 open for reaching tftp
server during pxebooting. It's not always open.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>