### PR TITLE
Fix ocp_cleanup to work for root user

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -12,5 +12,5 @@ fi
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf
 
 # Cleanup ssh keys for baremetal network
-sed -i "/^192.168.111/d" /home/$USER/.ssh/known_hosts
-sed -i "/^api.${CLUSTER_DOMAIN}/d" /home/$USER/.ssh/known_hosts
+sed -i "/^192.168.111/d" $HOME/.ssh/known_hosts
+sed -i "/^api.${CLUSTER_DOMAIN}/d" $HOME/.ssh/known_hosts


### PR DESCRIPTION
Some home dirs may be outside of `/home` (for instance root), so lets use `$HOME` instead