### PR TITLE
Force remove Ironic containers

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -82,12 +82,12 @@ popd
 
 for name in ironic ironic-inspector ; do 
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
-    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name
+    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done
 
 # Remove existing pod
 if  sudo podman pod exists ironic-pod ; then 
-    sudo podman pod rm ironic-pod
+    sudo podman pod rm ironic-pod -f
 fi
 
 # Create pod

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -6,12 +6,12 @@ source common.sh
 # Kill and remove the running ironic containers
 for name in ironic ironic-inspector ; do 
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
-    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name
+    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done
 
 # Remove existing pod
 if  sudo podman pod exists ironic-pod ; then
-    sudo podman pod rm ironic-pod
+    sudo podman pod rm ironic-pod -f
 fi
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \


### PR DESCRIPTION
My metalkube got into a weird state, and it couldn't clean up the Ironic containers.  Adding `-f` to podman commands fixed it.

This is the error I was getting:

```
732baa71d7665a696fee45f84b38d035fd3cd77b4fe01c26b882516f34c7ddc3
cannot remove container 732baa71d7665a696fee45f84b38d035fd3cd77b4fe01c26b882516f34c7ddc3 as it has active exec sessions: container state improper
```