### PR TITLE
Ensuring the file to edit exists.

### DIFF
--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -12,5 +12,7 @@ fi
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf
 
 # Cleanup ssh keys for baremetal network
-sed -i "/^192.168.111/d" $HOME/.ssh/known_hosts
-sed -i "/^api.${CLUSTER_DOMAIN}/d" $HOME/.ssh/known_hosts
+if [ -f $HOME/.ssh/known_hosts ]; then
+    sed -i "/^192.168.111/d" $HOME/.ssh/known_hosts
+    sed -i "/^api.${CLUSTER_DOMAIN}/d" $HOME/.ssh/known_hosts
+fi


### PR DESCRIPTION
This PR comes to apply a check prior to editing a file that may not exist,
which would cause the following error:
sed: can't read /home/stack/.ssh/known_hosts: No such file or directory

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>