### PR TITLE
Switch to kube-system namespace for kubevirt manifests

### DIFF
--- a/manifests/10_cnv_kubevirt_op.yaml
+++ b/manifests/10_cnv_kubevirt_op.yaml
@@ -1,11 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    kubevirt.io: ""
-  name: kubevirt
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -58,7 +51,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: kubevirt-operator
-  namespace: kubevirt
+  namespace: kube-system
   labels:
     operator.kubevirt.io: ""
 ---
@@ -66,7 +59,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-operator
-  namespace: kubevirt
+  namespace: kube-system
   labels:
     operator.kubevirt.io: ""
 roleRef:
@@ -76,13 +69,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-operator
-    namespace: kubevirt
+    namespace: kube-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: virt-operator
-  namespace: kubevirt
+  namespace: kube-system
   labels:
     operator.kubevirt.io: "virt-operator"
 spec:

--- a/manifests/11_cnv_kubevirt_cr.yaml
+++ b/manifests/11_cnv_kubevirt_cr.yaml
@@ -3,6 +3,6 @@ apiVersion: kubevirt.io/v1alpha3
 kind: KubeVirt
 metadata:
   name: kubevirt
-  namespace: kubevirt
+  namespace: kube-system
 spec:
   imagePullPolicy: IfNotPresent

--- a/manifests/12_cnv_kubevirt_config.yaml
+++ b/manifests/12_cnv_kubevirt_config.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-config
-  namespace: kubevirt
+  namespace: kube-system
 data:
   debug.useEmulation: "true"


### PR DESCRIPTION
There is an issue when posting manifests using `kubevirt` namespace. This is a
workaround for the issue that is meant to later be reverted when we understand
why `kubevirt` namespace is failing.

Related to issue #141 