### PR TITLE
Add retry option to get_images script.

### DIFF
--- a/get_images.sh
+++ b/get_images.sh
@@ -4,7 +4,7 @@ set -xe
 source common.sh
 
 if [ ! -f "$RHCOS_IMAGE_FILENAME" ]; then
-    curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
+    curl --insecure --compressed --retry 3 -L -o "${RHCOS_IMAGE_FILENAME}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME}".gz
 fi
 
 mkdir -p "$IRONIC_DATA_DIR/html/images"
@@ -17,12 +17,13 @@ fi
 
 pushd "$IRONIC_DATA_DIR/html/images"
 if [ ! -f "${RHCOS_IMAGE_FILENAME_OPENSTACK}" ]; then
-    curl --insecure --compressed -L -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME_OPENSTACK}".gz
+    curl --insecure --compressed --retry 3 -L -o "${RHCOS_IMAGE_FILENAME_OPENSTACK}" "${RHCOS_IMAGE_URL}/${RHCOS_IMAGE_VERSION}/${RHCOS_IMAGE_FILENAME_OPENSTACK}".gz
 fi
 
 if [ ! -f ironic-python-agent.initramfs ]; then
-#    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar | tar -xf -
-    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/54c5a6de8ce5b9cfae83632a7d81000721d56071_786d88d2/ironic-python-agent.tar | tar -xf -
+#    curl --insecure --compressed --retry 3 -O -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar
+    curl --insecure --compressed --retry 3 -O -L https://images.rdoproject.org/master/rdo_trunk/54c5a6de8ce5b9cfae83632a7d81000721d56071_786d88d2/ironic-python-agent.tar
+    tar -xf ironic-python-agent.tar
 fi
 
 popd


### PR DESCRIPTION
Add retry to curl calls to avoid sporadic network issues while
downloading images, for e.g.:
++ curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar
++ tar -xf -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:02:07 --:--:--     0
  curl: (7) Failed connect to images.rdoproject.org:443; Connection timed out
  tar: This does not look like a tar archive
  tar: Exiting with failure status due to previous errors