### PR TITLE
Revert "Switch to kube-system namespace for kubevirt manifests"

### DIFF
--- a/manifests/10_cnv_kubevirt_op.yaml
+++ b/manifests/10_cnv_kubevirt_op.yaml
@@ -1,4 +1,11 @@
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubevirt.io: ""
+  name: kubevirt
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -51,7 +58,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: kubevirt-operator
-  namespace: kube-system
+  namespace: kubevirt
   labels:
     operator.kubevirt.io: ""
 ---
@@ -59,7 +66,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-operator
-  namespace: kube-system
+  namespace: kubevirt
   labels:
     operator.kubevirt.io: ""
 roleRef:
@@ -69,13 +76,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-operator
-    namespace: kube-system
+    namespace: kubevirt
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: virt-operator
-  namespace: kube-system
+  namespace: kubevirt
   labels:
     operator.kubevirt.io: "virt-operator"
 spec:

--- a/manifests/11_cnv_kubevirt_cr.yaml
+++ b/manifests/11_cnv_kubevirt_cr.yaml
@@ -3,6 +3,6 @@ apiVersion: kubevirt.io/v1alpha3
 kind: KubeVirt
 metadata:
   name: kubevirt
-  namespace: kube-system
+  namespace: kubevirt
 spec:
   imagePullPolicy: IfNotPresent

--- a/manifests/12_cnv_kubevirt_config.yaml
+++ b/manifests/12_cnv_kubevirt_config.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-config
-  namespace: kube-system
+  namespace: kubevirt
 data:
   debug.useEmulation: "true"


### PR DESCRIPTION
Subsequent discussion indicates this isn't the right approach, and that
we instead need to fix the manifest ordering, and/or use a temporary
script that runs after the cluster is fully deployed.

This reverts commit a52d2b31ae239becee39f2c882601d55801efd19.