### PR TITLE
switch to a fixed known-good IPA image

### DIFF
--- a/get_images.sh
+++ b/get_images.sh
@@ -21,7 +21,8 @@ if [ ! -f "${RHCOS_IMAGE_FILENAME_OPENSTACK}" ]; then
 fi
 
 if [ ! -f ironic-python-agent.initramfs ]; then
-    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar | tar -xf -
+#    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/current-tripleo/ironic-python-agent.tar | tar -xf -
+    curl --insecure --compressed -L https://images.rdoproject.org/master/rdo_trunk/54c5a6de8ce5b9cfae83632a7d81000721d56071_786d88d2/ironic-python-agent.tar | tar -xf -
 fi
 
 popd


### PR DESCRIPTION
Something broke in the image built from the tip of the rocky
branch (see https://bugs.launchpad.net/tripleo/+bug/1818554 for
details). This patch uses a fixed build that seems to work to avoid
having to chase issues with the build off of the tip of the branch.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>