### PR TITLE
Forward $CLUSTER_DOMAIN DNS resolution against host dnsmasq instance

### DIFF
--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -71,8 +71,10 @@ done
 
 # NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
 IP=$(domain_net_ip ${CLUSTER_NAME}-bootstrap baremetal)
+BAREMETAL_BRIDGE_IP=$(network_ip baremetal)
 export API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip baremetal) | awk '{print $NF}')
 echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+echo "server=/${CLUSTER_DOMAIN}/${BAREMETAL_BRIDGE_IP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
 sudo systemctl reload NetworkManager
 
 # Wait for ssh to start


### PR DESCRIPTION
Forward DNS resolution requests for $CLUSTER_DOMAIN to the local dnasmsq
instance.  This enables DNS resolution using the libvirt network config
that we already have in place.  This allows us to access the masters by
their DNS hostname, e.g. master-<index>.$CLUSTER_DOMAIN.