### PR TITLE
02: Clean up some expected error output.

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -42,17 +42,17 @@ EOF
 fi
 
 # Allow ipmi to the virtual bmc processes that we just started
-if ! sudo iptables -C INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCEPT ; then
+if ! sudo iptables -C INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCEPT 2>/dev/null ; then
     sudo iptables -I INPUT -i baremetal -p udp -m udp --dport 6230:6235 -j ACCEPT
 fi
 
 #Allow access to dualboot.ipxe
-if ! sudo iptables -C INPUT -p tcp --dport 80 -j ACCEPT ; then
+if ! sudo iptables -C INPUT -p tcp --dport 80 -j ACCEPT 2>/dev/null ; then
     sudo iptables -I INPUT -p tcp --dport 80 -j ACCEPT
 fi
 
 #Allow access to tftp server for pxeboot
-if ! sudo iptables -C INPUT -p udp --dport 69 -j ACCEPT ; then
+if ! sudo iptables -C INPUT -p udp --dport 69 -j ACCEPT 2>/dev/null ; then
     sudo iptables -I INPUT -p udp --dport 69 -j ACCEPT
 fi
 
@@ -63,12 +63,12 @@ if [ "$EXT_IF" ]; then
 fi
 
 # Add access to backend Facet server from remote locations
-if ! sudo iptables -C INPUT -p tcp --dport 8080 -j ACCEPT ; then
+if ! sudo iptables -C INPUT -p tcp --dport 8080 -j ACCEPT 2>/dev/null ; then
   sudo iptables -I INPUT -p tcp --dport 8080 -j ACCEPT
 fi
 
 # Add access to Yarn development server from remote locations
-if ! sudo iptables -C INPUT -p tcp --dport 3000 -j ACCEPT ; then
+if ! sudo iptables -C INPUT -p tcp --dport 3000 -j ACCEPT 2>/dev/null ; then
   sudo iptables -I INPUT -p tcp --dport 3000 -j ACCEPT
 fi
 


### PR DESCRIPTION
The checks for existing iptables rules produces output at the end of this
script that makes it look like some failures occurred.  Since these are
expected and handled gracefully, send the error output to /dev/null.

Signed-off-by: Russell Bryant <rbryant@redhat.com>